### PR TITLE
Uses unicode escapes in tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcites
 Type: Package
 Title: R Interface to the Species+ Database
-Version: 1.3.0
+Version: 1.3.0.9000
 Authors@R: c(
   person("Kevin", "Cazelles", role = c("aut", "cre"), email = "kevin.cazelles@gmail.com", comment = c(ORCID = "0000-0001-6619-9874")),
   person("Jonas", "Geschke", role = c("aut"), email = "jonas.e.geschke@gmail.com", comment = c(ORCID = "0000-0002-5654-9313")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# rcites devel
+
+* Uses unicode escapes for "é" in tests.
+
+
 # rcites 1.3.0
 
 * `set_token()` now keeps prompting a message as long as the token is an empty 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci/rcites",
   "issueTracker": "https://github.com/ropensci/rcites/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.3.0",
+  "version": "1.3.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -202,7 +202,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "1963.115KB",
+  "fileSize": "1963.126KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -250,7 +250,7 @@
       ],
       "name": "{rcites}: An R package to access the CITES Species+ database",
       "url": "https://docs.ropensci.org/rcites/",
-      "description": "R package version 1.3.0"
+      "description": "R package version 1.3.0.9000"
     }
   ],
   "releaseNotes": "https://github.com/ropensci/rcites/blob/master/NEWS.md",

--- a/tests/testthat/test-distributions.R
+++ b/tests/testthat/test-distributions.R
@@ -1,4 +1,4 @@
-lang_GQ <- c("Equatorial Guinea", "Guinée équatoriale", "Guinea Ecuatorial")
+lang_GQ <- c("Equatorial Guinea", "Guin\u00e9e \u00e9quatoriale", "Guinea Ecuatorial")
 
 
 suppressMessages({


### PR DESCRIPTION
* Uses unicode escapes for "é" in tests.